### PR TITLE
Actualización de Lean a 3.28.0

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "IMO_en_Lean"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.24.0"
+lean_version = "leanprover-community/lean:3.28.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "e5f9409cd645db4734e2fd09e6d1a120e8405dd0"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "26fcfbc9cf56b9cdb11c179c7ff9c8ca0a4674e2"}


### PR DESCRIPTION
Está lista para mezclar. Después se puede comprobar que todo funciona ejecutando "leanpkg test".