### PR TITLE
Revisión del 14-mar-21

### DIFF
--- a/doc/Elementos.tex
+++ b/doc/Elementos.tex
@@ -120,7 +120,7 @@ begin
   cases hb (eps/2) (by linarith) with N2 hN2,
   let N0:=max N1 N2,
   calc  |a-b|
-      = |(a-u N0)+(u N0-b)| : by ring
+      = |(a-u N0)+(u N0-b)| : by ring_nf
   ... ≤ |a-u N0| + |u N0-b| : by apply abs_add
   ... = |u N0-a| + |u N0-b| : by rw abs_sub
   ... ≤ eps                 : by linarith [hN1 N0 (le_max_left N1 N2),

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,4 +5,4 @@ lean_version = "leanprover-community/lean:3.28.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "5be0b0c524095d38509ea9387139629241844b76"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "fd5f4333d48a1c576307108ef346da58cfab930a"}

--- a/src/Elementos/Unicidad_del_limite.lean
+++ b/src/Elementos/Unicidad_del_limite.lean
@@ -30,7 +30,7 @@ begin
   cases hb (eps/2) (by linarith) with N2 hN2,
   let N0:=max N1 N2,
   calc  |a-b|
-      = |(a-u N0)+(u N0-b)| : by ring
+      = |(a-u N0)+(u N0-b)| : by ring_nf
   ... ≤ |a-u N0| + |u N0-b| : by apply abs_add
   ... = |u N0-a| + |u N0-b| : by rw abs_sub
   ... ≤ eps                 : by linarith [hN1 N0 (le_max_left N1 N2),


### PR DESCRIPTION
He adaptado el proyecto a la versión fd5f4333d48a1c576307108ef346da58cfab930a de mathlib para que pudiera cargar el imo1962_q4.lean

Para el cambio, además de las modificaciones en el proyecto, he ejecutado 
   leanproject get-mathlib-cache
